### PR TITLE
Resolve audit report findings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,3 +3,4 @@ optimizer = true
 optimizer_runs = 10_000
 solc_version = "0.8.28"
 via_ir = true
+evm_version = "shanghai"

--- a/src/yWAPE.sol
+++ b/src/yWAPE.sol
@@ -103,6 +103,7 @@ contract yWAPE is ERC20, IWETH9 {
      */
     function _deposit(address to, uint256 nativeAmount) internal {
         if (nativeAmount == 0) revert ZeroDeposit();
+        if (to == address(0)) revert ZeroAddress();
         uint256 sharesToMint = _nativeToShares(nativeAmount);
 
         _mint(to, sharesToMint);

--- a/test/yWAPE.test.sol
+++ b/test/yWAPE.test.sol
@@ -289,6 +289,17 @@ contract yWAPETest is Test {
         }
     }
 
+    function testFuzzDeposit(uint256 amount) public {
+        amount = bound(amount, 0.0000001 ether, 1_000_000 ether);
+        vm.deal(alice, amount);
+        vm.prank(alice);
+        token.deposit{value: amount}();
+
+        assertEq(token.balanceOf(alice), amount);
+        assertEq(address(token).balance, amount);
+        assertEq(token.totalSupply(), amount);
+    }
+
     function testFuzzMultipleDeposits(uint256 amount1, uint256 amount2, uint256 yieldAmount) public {
         // Bound inputs to reasonable ranges
         amount1 = bound(amount1, 1, 100 ether);
@@ -425,5 +436,10 @@ contract yWAPETest is Test {
     function testRevertZeroDeposit() public {
         vm.expectRevert(ZeroDeposit.selector);
         token.deposit{value: 0}();
+    }
+
+    function testRevertZeroAddress() public {
+        vm.expectRevert(ZeroAddress.selector);
+        token.deposit{value: 0.5 ether}(address(0));
     }
 }


### PR DESCRIPTION
These two commits address findings in Halborn's preliminary audit report for yWAPE:

### **_7.1 (HAL-01) POSSIBLE LOSS OF FUNDS THROUGH DEPOSITS TO ZERO ADDRESS_**
>
> **Description**
> The yWAPE contract, which inherits from Solady's ERC20 implementation, allows deposits to be made to the
> zero address. While the contract includes a zero address check in the withdraw(address dst, uint256
> wad) function, there is no such validation in either the deposit(address to) or internal _deposit(address
> to, uint256 amount) functions. This oversight could lead to permanent loss of funds, as any native tokens
> deposited to generate shares for the zero address would be irretrievable.
> The issue arises because Solady's ERC20 implementation explicitly mentions that it allows operations with
> the zero address for performance reasons, leaving it up to the implementing contract to add such
> protections. From Solady's documentation:
> ```
> /// @dev Note:
> /// - The ERC20 standard allows minting and transferring to and from the zero address,
> ///   minting and transferring zero tokens, as well as self-approvals.
> ///   For performance, this implementation WILL NOT revert for such actions.
> ///   Please add any checks with overrides if desired.
> ```
>
> **Proof of Concept**
> In the following scenario, the deposit can be made on behalf of the zero address, resulting in loss of funds:
> ```
> function test_depositToAddressZero()  public  {
>     uint256 depositAmount = 1 ether;
>     address to = address(0);
>     vm.expectEmit(true, false, false, false);
>     emit Deposit(to, depositAmount);
>     vm.prank(alice);
>     token.deposit{value: depositAmount}(to);
>     assertEq(token.balanceOf(to), depositAmount);
>     console.log("Token balance of zero address: ", token.balanceOf(to));
>     assertEq(address(token).balance, depositAmount);
> }
> ```
>
> **BVSS**
> AO:A/AC:L/AX:L/R:N/S:U/C:N/A:N/I:N/D:M/Y:N (5.0)
>
> **Recommendation**
> Add a zero address check in the internal _deposit() function to protect against deposits to the zero
> address.

**Response:** The test case relies on user-error, specifically a user choosing to specify the zero-address as the beneficiary of their deposit by explicitly passing `address(0)`. In order to maximize depositor protections, we'll add an assertion preventing the zero-address from being used in the deposit flow.

**Action taken:** Added an explicit revert in case of the zero-address being used within the `_deposit` function.

### **_7.2 (HAL-02) RISK OF EVM VERSION INCOMPATIBILITY ACROSS CHAINS_**
>
> **Description**
> From Solidity versions 0.8.20 through 0.8.24, the default target EVM version is set to Shanghai, which
> results in the generation of bytecode that includes PUSH0 opcodes. Starting with version 0.8.25, the default
> EVM version shifts to Cancun, introducing new opcodes for transient storage, TSTORE and TLOAD.
> In this aspect, since the current code in scope uses complier version 0.8.28, it is crucial to select the
> appropriate EVM version when it's intended to deploy the contracts on networks other than the Ethereum
> mainnet, which may not support these opcodes. Failure to do so could lead to unsuccessful contract
> deployments or transaction execution issues.
> 
> **BVSS**
> AO:S/AC:L/AX:L/R:N/S:U/C:L/A:L/I:L/D:N/Y:N (0.8)
> 
> **Recommendation**
> Make sure to specify the target EVM version when using Solidity versions from 0.8.20 and above if deploying
> to chains that may not support newly introduced opcodes. Additionally, it is crucial to stay informed about
> the opcode support of different chains to ensure smooth deployment and compatibility.

**Response:** This is a deployment specifically and solely for ApeChain (which properly supports all compiler features we're using), so pinning a particular compiler target has zero impact. However, we'll pin an EVM target for posterity.

**Action taken:** Pinned Shanghai as the compiler target in `foundry.toml`